### PR TITLE
Fix language store for client side

### DIFF
--- a/hooks/use-language.ts
+++ b/hooks/use-language.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { Language } from '@/lib/i18n/translations'


### PR DESCRIPTION
## Summary
- ensure the language store is only used on the client

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512bd109f4832abb051e0b959549a1