### PR TITLE
feat: verify access token in middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_JWT_SECRET=your_supabase_jwt_secret
 
 # Authentication Configuration
 # NEXT_PUBLIC_SITE_URL is used for redirects in authentication flows


### PR DESCRIPTION
## Summary
- verify `sb-access-token` cookie before calling Supabase
- add SUPABASE_JWT_SECRET env var example

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy SUPABASE_JWT_SECRET=dummy npm run build` *(fails: 'supabase' is possibly 'null')*


------
https://chatgpt.com/codex/tasks/task_e_68ae9b1563b4832a8b50975aace469b8