### PR TITLE
fix: robust UUID generation for client/server

### DIFF
--- a/app/api/middleware.ts
+++ b/app/api/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getUUID } from '@/lib/uuid'
 import { logServerMessage } from '@/lib/server-logger'
 
 /**
@@ -11,7 +12,7 @@ export function withApiLogging(handler: (req: NextRequest) => Promise<NextRespon
     const pathname = req.nextUrl.pathname
 
     // Generate a unique request ID
-    const requestId = crypto.randomUUID()
+    const requestId = getUUID()
 
     // Extract query parameters
     const { searchParams } = new URL(url)

--- a/app/client-init.tsx
+++ b/app/client-init.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+// Ensure client runtime polyfills are applied early.
+import "@/lib/polyfills"
+
+export default function ClientInit() {
+  // No UI — just side effects (polyfills)
+  return null
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { AuthProvider } from "@/components/auth/auth-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { Header } from "./components/header"
+import ClientInit from "./client-init"
 import "./globals.css"
 import type React from "react"
 
@@ -23,6 +24,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} ${ibmPlexSansArabic.variable} min-h-screen bg-background antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <ClientInit />
           <AuthProvider>
             <div className="relative flex min-h-screen flex-col">
               <Header />
@@ -41,4 +43,3 @@ export default function RootLayout({
     </html>
   )
 }
-

--- a/lib/database/database-service.ts
+++ b/lib/database/database-service.ts
@@ -1,6 +1,7 @@
 // Main database service class
 
 import type { ProcessingStatus, OCRResult } from '@/types'
+import { getUUID } from '@/lib/uuid'
 import type { DatabaseStats } from '@/types/settings'
 import * as QueueService from './services/queue-service'
 import * as ResultsService from './services/results-service'
@@ -146,7 +147,7 @@ class DatabaseService {
     const camelCaseResults = results.map(result => ({
       ...result,
       documentId,
-      id: result.id || crypto.randomUUID()
+      id: result.id || getUUID()
     }))
 
     this.cache.results.set(documentId, camelCaseResults)

--- a/lib/database/services/document-service.ts
+++ b/lib/database/services/document-service.ts
@@ -2,6 +2,7 @@
 
 import { getUser } from '../../auth'
 import type { ProcessingStatus } from '@/types'
+import { getUUID } from '@/lib/uuid'
 import { supabase, isSupabaseConfigured, mapToProcessingStatus, camelToSnake } from '../utils'
 
 /**
@@ -136,7 +137,7 @@ export async function saveDocument(document: Partial<ProcessingStatus>): Promise
     createdAt: document.createdAt || new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     // If it's a new document, generate an ID
-    id: document.id || crypto.randomUUID()
+    id: document.id || getUUID()
   }
 
   // Convert to snake_case for Supabase

--- a/lib/database/services/results-service.ts
+++ b/lib/database/services/results-service.ts
@@ -1,6 +1,7 @@
 // Results-related database operations
 
 import { getUser } from '../../auth'
+import { getUUID } from '@/lib/uuid'
 import type { OCRResult } from '@/types'
 // camelToSnake is imported but not used in this file
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -87,7 +88,7 @@ export async function saveResults(documentId: string, results: OCRResult[]): Pro
     const preparedResult = {
       ...rest, // Include remaining properties
       document_id: documentId, // Always use the parameter value for document_id
-      id: result.id || crypto.randomUUID(),
+      id: result.id || getUUID(),
       user_id: userId,
       text: result.text || '',
       confidence: result.confidence || 0,

--- a/lib/indexed-db.ts
+++ b/lib/indexed-db.ts
@@ -1,4 +1,6 @@
 import { openDB, type IDBPDatabase } from 'idb'
+import "@/lib/polyfills"
+import { getUUID } from '@/lib/uuid'
 import type { ProcessingStatus, OCRResult } from '@/types'
 import type { DatabaseStats } from '@/types/settings'
 
@@ -251,7 +253,7 @@ class DatabaseService {
       results.map(result => tx.store.put({
         ...result,
         documentId,
-        id: result.id || crypto.randomUUID()
+        id: result.id || getUUID()
       }))
     )
     await tx.done
@@ -263,4 +265,3 @@ class DatabaseService {
 }
 
 export const db = new DatabaseService()
-

--- a/lib/ocr/file-processor.ts
+++ b/lib/ocr/file-processor.ts
@@ -6,6 +6,7 @@ import type { OCRProvider } from "./providers/types";
 import { MistralOCRProvider } from "./providers/mistral";
 import { getUser } from "@/lib/auth";
 import { getSupabaseClient } from "@/lib/supabase/singleton-client";
+import { getUUID } from "@/lib/uuid";
 
 // Configuration
 const STORAGE_CONFIG = {
@@ -105,7 +106,7 @@ export class FileProcessor {
       if (!user) throw new Error("User not authenticated");
 
       // Generate a unique ID for the OCR result
-      const resultId = crypto.randomUUID();
+      const resultId = getUUID();
 
       // Use the storage path from the status object (already uploaded in queue manager)
       const path = status.storagePath;
@@ -183,7 +184,7 @@ export class FileProcessor {
               }
 
               // Generate a unique ID for the OCR result
-              const resultId = crypto.randomUUID();
+              const resultId = getUUID();
 
               // Use the storage path from the status object (already uploaded in queue manager)
               const pdfPath = status.storagePath;
@@ -395,7 +396,7 @@ export class FileProcessor {
       if (!user) throw new Error("User not authenticated");
 
       // Generate a unique ID for the OCR result
-      const resultId = crypto.randomUUID();
+      const resultId = getUUID();
 
       const blob = await this.base64ToBlob(base64Data, 'image/jpeg');
       // Use the new naming convention: Page_(page_number).(image_extension)
@@ -470,7 +471,7 @@ export class FileProcessor {
 
       // Create an error result
       const errorResult: OCRResult = {
-        id: crypto.randomUUID(),
+        id: getUUID(),
         documentId: status.id,
         text: `Error processing page ${pageNum}: ${error instanceof Error ? error.message : String(error)}`,
         confidence: 0,

--- a/lib/ocr/providers/google.ts
+++ b/lib/ocr/providers/google.ts
@@ -1,4 +1,5 @@
 import type { OCRResult, OCRSettings } from "@/types";
+import { getUUID } from "@/lib/uuid";
 import type { OCRProvider } from "./types";
 
 export class GoogleVisionProvider implements OCRProvider {
@@ -48,7 +49,7 @@ export class GoogleVisionProvider implements OCRProvider {
 
     if (!result?.fullTextAnnotation) {
       return {
-        id: crypto.randomUUID(),
+        id: getUUID(),
         documentId: "",
         text: "",
         confidence: 0,
@@ -59,7 +60,7 @@ export class GoogleVisionProvider implements OCRProvider {
     }
 
     return {
-      id: crypto.randomUUID(),
+      id: getUUID(),
       documentId: "",
       text: result.fullTextAnnotation.text,
       confidence: result.fullTextAnnotation.pages?.[0]?.confidence || 1,

--- a/lib/ocr/providers/microsoft.ts
+++ b/lib/ocr/providers/microsoft.ts
@@ -1,4 +1,5 @@
 import type { OCRResult, OCRSettings } from "@/types";
+import { getUUID } from "@/lib/uuid";
 import { AzureRateLimiter } from "../rate-limiter";
 import type { MicrosoftVisionResponse, OCRProvider } from "./types";
 
@@ -83,7 +84,7 @@ export class MicrosoftVisionProvider implements OCRProvider {
           .join("\n\n") || "";
 
       return {
-        id: crypto.randomUUID(),
+        id: getUUID(),
         documentId: "",
         text,
         confidence: 1,

--- a/lib/ocr/providers/mistral.ts
+++ b/lib/ocr/providers/mistral.ts
@@ -1,4 +1,5 @@
 import type { OCRResult, OCRSettings } from "@/types";
+import { getUUID } from "@/lib/uuid";
 import type { MistralOCRResponse, OCRProvider } from "./types";
 import { MistralRateLimiter } from "../rate-limiter";
 
@@ -109,7 +110,7 @@ export class MistralOCRProvider implements OCRProvider {
           } else {
             // Return a special result indicating rate limiting
             return {
-              id: crypto.randomUUID(),
+              id: getUUID(),
               documentId: "",
               text: "Rate limit exceeded. Please try again later.",
               confidence: 0,
@@ -222,7 +223,7 @@ export class MistralOCRProvider implements OCRProvider {
         console.log(`[Mistral] Successfully processed image page ${pageNumber}/${totalPages}`);
 
         return {
-          id: crypto.randomUUID(),
+          id: getUUID(),
           documentId: "",
           text: extractedText,
           confidence: 1, // Mistral doesn't provide confidence scores, so we use 1
@@ -486,7 +487,7 @@ export class MistralOCRProvider implements OCRProvider {
       this.rateLimiter.setRateLimit(retryDelaySeconds);
 
       return {
-        id: crypto.randomUUID(),
+        id: getUUID(),
         documentId: "",
         text: `Rate limited. Will retry after ${retryDelaySeconds}s.`,
         confidence: 0,
@@ -563,7 +564,7 @@ export class MistralOCRProvider implements OCRProvider {
     console.log(`[Mistral] Successfully processed PDF with ${totalPages} page(s)`);
 
     return {
-      id: crypto.randomUUID(),
+      id: getUUID(),
       documentId: "",
       text: extractedText,
       confidence: 1, // Mistral doesn't provide confidence scores, so we use 1

--- a/lib/ocr/queue-manager.ts
+++ b/lib/ocr/queue-manager.ts
@@ -1,8 +1,10 @@
 import type { ProcessingStatus } from "@/types";
+import "@/lib/polyfills";
 import type { ProcessingSettings, UploadSettings } from "@/types/settings";
 import { db } from "../database";
 import { FileProcessor } from "./file-processor";
 import { updateDocumentStatus, retryDocument as retryDocumentUtil } from "./document-status-utils";
+import { getUUID } from "@/lib/uuid";
 
 export class QueueManager {
   private queueMap: Map<string, ProcessingStatus> = new Map();
@@ -72,7 +74,7 @@ export class QueueManager {
         throw new Error(`Invalid file: ${file.name}`);
       }
 
-      const id = crypto.randomUUID();
+      const id = getUUID();
       const now = new Date();
 
       // Generate a storage path for the file using the new naming convention

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,0 +1,45 @@
+// Polyfills and safe shims for browser/runtime gaps
+// Currently: crypto.randomUUID fallback for older browsers/environments
+
+// Lightweight RFC4122 v4 generator using crypto.getRandomValues when available
+function uuidV4(): string {
+  const bytes = new Uint8Array(16);
+  if (typeof globalThis !== 'undefined') {
+    try {
+      if (globalThis.crypto && typeof globalThis.crypto.getRandomValues === 'function') {
+        globalThis.crypto.getRandomValues(bytes);
+      } else {
+        for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0;
+      }
+    } catch {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0;
+    }
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0;
+  }
+
+  // Per RFC 4122 §4.4 set version and variant bits
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // Version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // Variant 10
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+// Install polyfill if missing
+(() => {
+  try {
+    if (typeof globalThis !== 'undefined') {
+      const gCrypto: any = (globalThis as any).crypto;
+      if (!gCrypto || typeof gCrypto.randomUUID !== 'function') {
+        const randomUUID = uuidV4;
+        const nextCrypto = { ...(gCrypto || {}), randomUUID } as any;
+        (globalThis as any).crypto = nextCrypto;
+      }
+    }
+  } catch {
+    // Silently ignore — best-effort polyfill for environments that disallow mutation
+  }
+})();
+
+export {};

--- a/lib/server-console-logger.ts
+++ b/lib/server-console-logger.ts
@@ -3,6 +3,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
+import { getUUID } from '@/lib/uuid'
 import { serverLog, serverError } from './log'
 
 /**
@@ -16,7 +17,7 @@ export function logApiRequestToConsole(
   url: string,
   params?: Record<string, unknown>
 ) {
-  const requestId = crypto.randomUUID().substring(0, 8)
+  const requestId = getUUID().substring(0, 8)
 
   // Note: We're not logging headers to avoid exposing sensitive information
 
@@ -50,7 +51,7 @@ export function withConsoleApiLogging(handler: (req: NextRequest) => Promise<Nex
     const pathname = req.nextUrl.pathname
 
     // Generate a unique request ID
-    const requestId = crypto.randomUUID().substring(0, 8)
+    const requestId = getUUID().substring(0, 8)
 
     // Extract query parameters if needed in the future
     // const { searchParams } = new URL(url)

--- a/lib/server-logger.ts
+++ b/lib/server-logger.ts
@@ -5,6 +5,7 @@
 import fs from 'fs'
 import path from 'path'
 import { NextRequest, NextResponse } from 'next/server'
+import { getUUID } from '@/lib/uuid'
 import { debugLog, prodError } from './log'
 
 // Configure log directory and file
@@ -43,7 +44,7 @@ export function logApiRequest(
   body?: Record<string, unknown>
 ) {
   const timestamp = new Date().toISOString()
-  const requestId = crypto.randomUUID()
+  const requestId = getUUID()
 
   const logEntry = {
     timestamp,

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -1,0 +1,32 @@
+// UUID utilities
+// Provides getUUID() that prefers crypto.randomUUID with a safe fallback.
+
+// Lightweight RFC4122 v4 generator using crypto.getRandomValues when available
+function uuidV4Fallback(): string {
+  const bytes = new Uint8Array(16)
+  try {
+    if (globalThis.crypto && typeof globalThis.crypto.getRandomValues === 'function') {
+      globalThis.crypto.getRandomValues(bytes)
+    } else {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0
+    }
+  } catch {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40 // Version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80 // Variant 10
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+export function getUUID(): string {
+  try {
+    const rnd = globalThis?.crypto?.randomUUID?.()
+    return rnd || uuidV4Fallback()
+  } catch {
+    return uuidV4Fallback()
+  }
+}
+

--- a/middleware-api-logger.ts
+++ b/middleware-api-logger.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { getUUID } from '@/lib/uuid'
 import { logApiRequest, logApiResponse, logServerMessage } from './lib/server-logger'
 
 /**
@@ -17,7 +18,7 @@ export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
   
   // Generate a unique request ID
-  const requestId = crypto.randomUUID()
+  const requestId = getUUID()
   
   // Extract query parameters
   const { searchParams } = new URL(url)


### PR DESCRIPTION
### Description du PR
Ce correctif améliore la génération d’UUID dans toute l’application, en remplaçant `crypto.randomUUID()` par une fonction `getUUID()` garantissant un fallback sécurisé via un polyfill client.

#### Changements clés
- Utilisation d’un **polyfill** pour `crypto.randomUUID` côté client, chargé très tôt via `client-init.tsx`
- Introduction d’un utilitaire `getUUID()` dans `lib/uuid`
- Remplacement systématique de tous les appels directs à `crypto.randomUUID()` par `getUUID()`
- Chargement des polyfills avant tout rendu client, pour garantir une exécution fiable

#### Bénéfices
- Réduction des plantages liés à `crypto.randomUUID` manquante
- Génération d’UUID plus fiable et cohérente, même dans les environnements les plus restrictifs
- Compatibilité rétroactive préservée

**Type de changement** : Bug fix, sans modification de l’API publique (Fixes upload crash: TypeError: crypto.randomUUID is not a function)