### PR TITLE
feat: confirm before cancel or delete

### DIFF
--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -82,6 +82,12 @@ interface TranslationKeys {
   tryAgain: string
   maxRetriesReached: string
 
+  // Confirmations
+  confirmDeleteTitle: string
+  confirmDeleteDesc: string
+  confirmCancelTitle: string
+  confirmCancelDesc: string
+
   // Document Preview
   sourceDocument: string
   extractedText: string
@@ -362,6 +368,12 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     tryAgain: 'Try Again',
     maxRetriesReached: 'Max Retries Reached',
 
+    // Confirmations
+    confirmDeleteTitle: 'Delete document?',
+    confirmDeleteDesc: 'Are you sure you want to delete this document? This action cannot be undone.',
+    confirmCancelTitle: 'Cancel processing?',
+    confirmCancelDesc: 'Are you sure you want to cancel processing for this document?',
+
     // Document Preview
     sourceDocument: 'Source Document',
     extractedText: 'Extracted Text',
@@ -637,6 +649,12 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     tryAgain: 'Réessayer',
     maxRetriesReached: 'Nombre maximal de tentatives atteint',
 
+    // Confirmations
+    confirmDeleteTitle: 'Supprimer le document ?',
+    confirmDeleteDesc: 'Êtes-vous sûr de vouloir supprimer ce document ? Cette action est irréversible.',
+    confirmCancelTitle: 'Annuler le traitement ?',
+    confirmCancelDesc: 'Êtes-vous sûr de vouloir annuler le traitement de ce document ?',
+
     // Document Preview
     sourceDocument: 'Document source',
     extractedText: 'Texte extrait',
@@ -900,6 +918,12 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     tryAgain: 'حاول مرة أخرى',
     maxRetriesReached: 'تم الوصول إلى الحد الأقصى للمحاولات',
 
+    // Confirmations
+    confirmDeleteTitle: 'حذف المستند؟',
+    confirmDeleteDesc: 'هل أنت متأكد أنك تريد حذف هذا المستند؟ لا يمكن التراجع عن هذا الإجراء.',
+    confirmCancelTitle: 'إلغاء المعالجة؟',
+    confirmCancelDesc: 'هل أنت متأكد أنك تريد إلغاء معالجة هذا المستند؟',
+
     // Document Preview
     sourceDocument: 'المستند المصدر',
     extractedText: 'النص المستخرج',
@@ -1154,6 +1178,12 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     downloaded: 'تم التحمیل',
     tryAgain: 'تلاش مجدد',
     maxRetriesReached: 'حداکثر تلاش‌ها انجام شد',
+
+    // Confirmations
+    confirmDeleteTitle: 'حذف سند؟',
+    confirmDeleteDesc: 'آیا مطمئن هستید که می‌خواهید این سند را حذف کنید؟ این عمل برگشت‌پذیر نیست.',
+    confirmCancelTitle: 'لغو پردازش؟',
+    confirmCancelDesc: 'آیا مطمئن هستید که می‌خواهید پردازش این سند را لغو کنید؟',
 
     // Document Preview
     sourceDocument: 'سند منبع',


### PR DESCRIPTION
## Summary
- add confirmation dialogs when canceling or deleting documents
- localize confirmation messages in English, French, Arabic and Farsi
- stop grid view menu actions from triggering navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2e13ed68832a8a758c7dba84556e