### PR TITLE
Centralize signed URL helpers and refresh viewer

### DIFF
--- a/lib/storage/signed-url.ts
+++ b/lib/storage/signed-url.ts
@@ -1,0 +1,50 @@
+import { supabase } from '@/lib/database/utils'
+import { getUser } from '@/lib/auth'
+
+/** TTL par défaut: 3600s (1h). Ajuste si besoin. */
+const DEFAULT_TTL = 3600
+
+/** Construit le chemin "bucket/userId/storagePath" attendu par le Storage. */
+function buildUserScopedPath(userId: string, storagePath: string) {
+  return `${userId}/${storagePath}`
+}
+
+/** Génère une URL signée pour un seul fichier. */
+export async function getSignedUrlFor(
+  bucket: string,
+  storagePath: string,
+  expiresIn: number = DEFAULT_TTL
+): Promise<string> {
+  const user = await getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const path = buildUserScopedPath(user.id, storagePath)
+  const { data, error } = await supabase.storage.from(bucket).createSignedUrl(path, expiresIn)
+  if (error || !data?.signedUrl) throw error ?? new Error('No signedUrl returned')
+
+  return data.signedUrl
+}
+
+/** Génère des URLs signées en lot. Retourne un mapping storagePath -> signedUrl. */
+export async function getSignedUrlsForBatch(
+  bucket: string,
+  storagePaths: string[],
+  expiresIn: number = DEFAULT_TTL
+): Promise<Record<string, string>> {
+  if (storagePaths.length === 0) return {}
+
+  const user = await getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const paths = storagePaths.map((p) => buildUserScopedPath(user.id, p))
+  const { data, error } = await supabase.storage.from(bucket).createSignedUrls(paths, expiresIn)
+  if (error || !data) throw error ?? new Error('No signedUrls returned')
+
+  // Supabase renvoie les objets dans le même ordre.
+  const out: Record<string, string> = {}
+  storagePaths.forEach((p, i) => {
+    const signed = data[i]?.signedUrl
+    if (signed) out[p] = signed
+  })
+  return out
+}


### PR DESCRIPTION
## Summary
- add `lib/storage/signed-url.ts` for generating signed URLs individually or in batch with short TTL
- refactor document viewer to use centralized helpers, batch ensure URLs, and refresh proactively before expiry
- retry image loads by regenerating signed URLs and reloading preview when an `<img>` fails to load

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af491b2c98832ab0958830f947f66e