### PR TITLE
feat: add user feedback for document actions

### DIFF
--- a/app/components/document-list.tsx
+++ b/app/components/document-list.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { FileText, MoreVertical, Download, Trash2, ImageIcon, Clock, Loader2, CheckCircle, AlertCircle, Pause, Eye } from "lucide-react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -16,6 +17,14 @@ import {
 } from "@/components/ui/tooltip"
 import { useLanguage } from "@/hooks/use-language"
 import { t, type Language } from "@/lib/i18n/translations"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
 
 interface DocumentListProps {
   documents: ProcessingStatus[]
@@ -119,6 +128,59 @@ export function DocumentList({
   const router = useRouter()
   const { language } = useLanguage()
 
+  const [pendingAction, setPendingAction] = useState<
+    { type: 'delete' | 'cancel'; id: string } | null
+  >(null)
+
+  const [busy, setBusy] = useState(false)
+
+  const handleConfirm = async () => {
+    if (!pendingAction) return
+    setBusy(true)
+    try {
+      if (pendingAction.type === 'delete') {
+        await Promise.resolve(onDelete(pendingAction.id))
+      } else if (pendingAction.type === 'cancel' && onCancel) {
+        await Promise.resolve(onCancel(pendingAction.id))
+      }
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setBusy(false)
+      setPendingAction(null)
+    }
+  }
+
+  const dialog = (
+    <Dialog open={!!pendingAction} onOpenChange={(open) => !open && setPendingAction(null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {pendingAction?.type === 'delete'
+              ? t('confirmDeleteTitle', language)
+              : t('confirmCancelTitle', language)}
+          </DialogTitle>
+          <DialogDescription>
+            {pendingAction?.type === 'delete'
+              ? t('confirmDeleteDesc', language)
+              : t('confirmCancelDesc', language)}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setPendingAction(null)} disabled={busy}>
+            {t('close', language)}
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={busy}>
+            {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {pendingAction?.type === 'delete'
+              ? t('delete', language)
+              : t('cancel', language)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+
   const canViewDocument = (doc: ProcessingStatus) => {
     if (doc.status === "completed") return true
     // Allow viewing cancelled files if they have some processed pages
@@ -184,64 +246,71 @@ export function DocumentList({
 
   if (isLoading) {
     return (
-      <div className="rounded-md border bg-card">
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead>{t('fileName', language)}</TableHead>
-              <TableHead>{t('status', language)}</TableHead>
-              <TableHead>{t('date', language)}</TableHead>
-              <TableHead>{t('pages', language)}</TableHead>
-              <TableHead>{t('size', language)}</TableHead>
-              <TableHead className="w-[100px] text-center">{t('actions', language)}</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {Array.from({ length: 3 }).map((_, i) => (
-              <TableRow key={i}>
-                <TableCell>
-                  <div className="flex items-center gap-4">
-                    <div className="h-4 w-4 rounded bg-muted animate-pulse" />
-                    <div className="h-4 w-48 bg-muted rounded animate-pulse" />
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                </TableCell>
-                <TableCell>
-                  <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                </TableCell>
-                <TableCell>
-                  <div className="h-4 w-12 bg-muted rounded animate-pulse" />
-                </TableCell>
-                <TableCell>
-                  <div className="h-4 w-16 bg-muted rounded animate-pulse" />
-                </TableCell>
-                <TableCell>
-                  <div className="flex justify-center">
-                    <div className="h-8 w-8 rounded bg-muted animate-pulse" />
-                  </div>
-                </TableCell>
+      <>
+        <div className="rounded-md border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>{t('fileName', language)}</TableHead>
+                <TableHead>{t('status', language)}</TableHead>
+                <TableHead>{t('date', language)}</TableHead>
+                <TableHead>{t('pages', language)}</TableHead>
+                <TableHead>{t('size', language)}</TableHead>
+                <TableHead className="w-[100px] text-center">{t('actions', language)}</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+            </TableHeader>
+            <TableBody>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell>
+                    <div className="flex items-center gap-4">
+                      <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                      <div className="h-4 w-48 bg-muted rounded animate-pulse" />
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+                  </TableCell>
+                  <TableCell>
+                    <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+                  </TableCell>
+                  <TableCell>
+                    <div className="h-4 w-12 bg-muted rounded animate-pulse" />
+                  </TableCell>
+                  <TableCell>
+                    <div className="h-4 w-16 bg-muted rounded animate-pulse" />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex justify-center">
+                      <div className="h-8 w-8 rounded bg-muted animate-pulse" />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        {dialog}
+      </>
     )
   }
 
   if (documents.length === 0) {
     return (
-      <div className="text-center py-8">
-        <p className="text-muted-foreground">{t('noDocuments', language)}</p>
-      </div>
+      <>
+        <div className="text-center py-8">
+          <p className="text-muted-foreground">{t('noDocuments', language)}</p>
+        </div>
+        {dialog}
+      </>
     )
   }
 
   if (variant === "grid") {
     return (
-      <div className="space-y-4">
-        {documents.map((doc) => (
+      <>
+        <div className="space-y-4">
+          {documents.map((doc) => (
           <div
             key={doc.id}
             className={cn(
@@ -284,7 +353,12 @@ export function DocumentList({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => onShowDetails(doc)}>
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onShowDetails(doc)
+                        }}
+                      >
                         <Eye className="mr-2 h-4 w-4" />
                         {t('viewDetails', language)}
                       </DropdownMenuItem>
@@ -295,7 +369,10 @@ export function DocumentList({
                               <TooltipTrigger asChild>
                                 <div>
                                   <DropdownMenuItem
-                                    onClick={() => onDownload(doc.id)}
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      onDownload(doc.id)
+                                    }}
                                     disabled={true}
                                     className="opacity-50 cursor-not-allowed"
                                   >
@@ -310,7 +387,12 @@ export function DocumentList({
                             </Tooltip>
                           </TooltipProvider>
                         ) : (
-                          <DropdownMenuItem onClick={() => onDownload(doc.id)}>
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              onDownload(doc.id)
+                            }}
+                          >
                             <Download className="h-4 w-4 mr-2" />
                             {t('download', language)}
                           </DropdownMenuItem>
@@ -319,7 +401,10 @@ export function DocumentList({
                       {/* Show cancel button for processing documents */}
                       {doc.status === 'processing' && onCancel && (
                         <DropdownMenuItem
-                          onClick={() => onCancel(doc.id)}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setPendingAction({ type: 'cancel', id: doc.id })
+                          }}
                         >
                           <Pause className="h-4 w-4 mr-2" />
                           {t('cancel', language) || 'Cancel'}
@@ -329,7 +414,10 @@ export function DocumentList({
                       {/* Show retry button for error/failed documents */}
                       {(doc.status === 'error' || doc.status === 'failed') && onRetry && (
                         <DropdownMenuItem
-                          onClick={() => onRetry(doc.id)}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onRetry(doc.id)
+                          }}
                         >
                           <Clock className="h-4 w-4 mr-2" />
                           {t('retry', language) || 'Retry'}
@@ -337,7 +425,10 @@ export function DocumentList({
                       )}
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
-                        onClick={() => onDelete(doc.id)}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setPendingAction({ type: 'delete', id: doc.id })
+                        }}
                       >
                         <Trash2 className="h-4 w-4 mr-2" />
                         {t('delete', language)}
@@ -350,13 +441,16 @@ export function DocumentList({
             {getProgressIndicator(doc)}
           </div>
         ))}
-      </div>
+        </div>
+        {dialog}
+      </>
     )
   }
 
   return (
-    <div className="rounded-md border bg-card">
-      <Table>
+    <>
+      <div className="rounded-md border bg-card">
+        <Table>
         <TableHeader>
           <TableRow className="hover:bg-transparent">
             <TableColumnHeader>{t('fileName', language)}</TableColumnHeader>
@@ -467,7 +561,7 @@ export function DocumentList({
                         <DropdownMenuItem
                           onClick={(e) => {
                             e.stopPropagation();
-                            onCancel(doc.id);
+                            setPendingAction({ type: 'cancel', id: doc.id });
                           }}
                         >
                           <Pause className="h-4 w-4 mr-2" />
@@ -492,7 +586,7 @@ export function DocumentList({
                         className="text-destructive focus:text-destructive"
                         onClick={(e) => {
                           e.stopPropagation();
-                          onDelete(doc.id);
+                          setPendingAction({ type: 'delete', id: doc.id });
                         }}
                       >
                         <Trash2 className="h-4 w-4 mr-2" />
@@ -505,7 +599,9 @@ export function DocumentList({
             </TableRow>
           ))}
         </TableBody>
-      </Table>
-    </div>
+        </Table>
+      </div>
+      {dialog}
+    </>
   )
 }

--- a/app/components/document-list.tsx
+++ b/app/components/document-list.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/tooltip"
 import { useLanguage } from "@/hooks/use-language"
 import { t, type Language } from "@/lib/i18n/translations"
+import { useToast } from "@/hooks/use-toast"
 import {
   Dialog,
   DialogContent,
@@ -127,6 +128,7 @@ export function DocumentList({
 }: DocumentListProps) {
   const router = useRouter()
   const { language } = useLanguage()
+  const { toast } = useToast()
 
   const [pendingAction, setPendingAction] = useState<
     { type: 'delete' | 'cancel'; id: string } | null
@@ -141,10 +143,26 @@ export function DocumentList({
       if (pendingAction.type === 'delete') {
         await Promise.resolve(onDelete(pendingAction.id))
       } else if (pendingAction.type === 'cancel' && onCancel) {
+        const doc = documents.find(d => d.id === pendingAction.id)
+        if (!doc || doc.status !== 'processing') {
+          toast({
+            title: t('error', language),
+            description: t('cancelError', language),
+            variant: 'destructive'
+          })
+          return
+        }
         await Promise.resolve(onCancel(pendingAction.id))
       }
     } catch (err) {
       console.error(err)
+      toast({
+        title: t('error', language),
+        description: pendingAction.type === 'delete'
+          ? t('deleteError', language)
+          : t('cancelError', language),
+        variant: 'destructive'
+      })
     } finally {
       setBusy(false)
       setPendingAction(null)
@@ -402,6 +420,7 @@ export function DocumentList({
                       {doc.status === 'processing' && onCancel && (
                         <DropdownMenuItem
                           onClick={(e) => {
+                            e.preventDefault()
                             e.stopPropagation()
                             setPendingAction({ type: 'cancel', id: doc.id })
                           }}
@@ -426,6 +445,7 @@ export function DocumentList({
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         onClick={(e) => {
+                          e.preventDefault()
                           e.stopPropagation()
                           setPendingAction({ type: 'delete', id: doc.id })
                         }}
@@ -560,6 +580,7 @@ export function DocumentList({
                       {doc.status === 'processing' && onCancel && (
                         <DropdownMenuItem
                           onClick={(e) => {
+                            e.preventDefault();
                             e.stopPropagation();
                             setPendingAction({ type: 'cancel', id: doc.id });
                           }}
@@ -585,6 +606,7 @@ export function DocumentList({
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         onClick={(e) => {
+                          e.preventDefault();
                           e.stopPropagation();
                           setPendingAction({ type: 'delete', id: doc.id });
                         }}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -139,9 +139,14 @@ export default function DocumentsPage() {
           }
         });
 
-        if (!cancelResponse.ok) {
-          console.error('[DEBUG] Failed to cancel processing:', await cancelResponse.text());
-        }
+      if (!cancelResponse.ok) {
+        console.error('[DEBUG] Failed to cancel processing:', await cancelResponse.text());
+        toast({
+          title: t('error', language),
+          description: t('cancelError', language),
+          variant: 'destructive'
+        });
+      }
       }
 
       // Delete the document
@@ -154,16 +159,30 @@ export default function DocumentsPage() {
 
       if (!deleteResponse.ok) {
         console.error('[DEBUG] Failed to delete document:', await deleteResponse.text());
+        toast({
+          title: t('error', language),
+          description: t('deleteError', language),
+          variant: 'destructive'
+        });
         return;
       }
 
       // Update the UI
       setDocuments((prev) => prev.filter((doc) => doc.id !== id));
       console.log('[DEBUG] Document deleted successfully');
+      toast({
+        title: t('success', language),
+        description: t('deleteSuccess', language)
+      });
     } catch (error) {
       console.error('[DEBUG] Error deleting document:', error);
+      toast({
+        title: t('error', language),
+        description: t('deleteError', language),
+        variant: 'destructive'
+      });
     }
-  }, [documents])
+  }, [documents, language, toast])
 
   const handleCancel = useCallback(async (id: string) => {
     try {
@@ -178,6 +197,11 @@ export default function DocumentsPage() {
 
       if (!cancelResponse.ok) {
         console.error('[DEBUG] Failed to cancel processing:', await cancelResponse.text());
+        toast({
+          title: t('error', language),
+          description: t('cancelError', language),
+          variant: 'destructive'
+        });
         return;
       }
 
@@ -187,10 +211,19 @@ export default function DocumentsPage() {
       ));
 
       console.log('[DEBUG] Processing canceled successfully');
+      toast({
+        title: t('success', language),
+        description: t('cancelSuccess', language)
+      });
     } catch (error) {
       console.error('[DEBUG] Error canceling processing:', error);
+      toast({
+        title: t('error', language),
+        description: t('cancelError', language),
+        variant: 'destructive'
+      });
     }
-  }, []);
+  }, [language, toast]);
 
   const handleRetry = useCallback(async (id: string) => {
     try {
@@ -330,7 +363,7 @@ export default function DocumentsPage() {
         variant: "destructive"
       })
     }
-  }, [documents, db, toast])
+  }, [documents, toast])
 
   return (
     <AuthCheck>

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -81,6 +81,16 @@ interface TranslationKeys {
   downloaded: string
   tryAgain: string
   maxRetriesReached: string
+  deleteSuccess: string
+  deleteError: string
+  cancelSuccess: string
+  cancelError: string
+
+  // Confirmations
+  confirmDeleteTitle: string
+  confirmDeleteDesc: string
+  confirmCancelTitle: string
+  confirmCancelDesc: string
 
   // Document Preview
   sourceDocument: string
@@ -361,6 +371,16 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     downloaded: 'Downloaded',
     tryAgain: 'Try Again',
     maxRetriesReached: 'Max Retries Reached',
+    deleteSuccess: 'Document deleted',
+    deleteError: 'Failed to delete document',
+    cancelSuccess: 'Processing cancelled',
+    cancelError: 'Failed to cancel processing',
+
+    // Confirmations
+    confirmDeleteTitle: 'Delete document?',
+    confirmDeleteDesc: 'Are you sure you want to delete this document? This action cannot be undone.',
+    confirmCancelTitle: 'Cancel processing?',
+    confirmCancelDesc: 'Are you sure you want to cancel processing for this document?',
 
     // Document Preview
     sourceDocument: 'Source Document',
@@ -634,8 +654,18 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     copied: 'Copié',
     download: 'Télécharger',
     downloaded: 'Téléchargé',
-    tryAgain: 'Réessayer',
+   tryAgain: 'Réessayer',
     maxRetriesReached: 'Nombre maximal de tentatives atteint',
+    deleteSuccess: 'Document supprimé',
+    deleteError: 'Échec de la suppression du document',
+    cancelSuccess: 'Traitement annulé',
+    cancelError: 'Échec de l\'annulation du traitement',
+
+    // Confirmations
+    confirmDeleteTitle: 'Supprimer le document ?',
+    confirmDeleteDesc: 'Êtes-vous sûr de vouloir supprimer ce document ? Cette action est irréversible.',
+    confirmCancelTitle: 'Annuler le traitement ?',
+    confirmCancelDesc: 'Êtes-vous sûr de vouloir annuler le traitement de ce document ?',
 
     // Document Preview
     sourceDocument: 'Document source',
@@ -899,6 +929,16 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     downloaded: 'تم التحميل',
     tryAgain: 'حاول مرة أخرى',
     maxRetriesReached: 'تم الوصول إلى الحد الأقصى للمحاولات',
+    deleteSuccess: 'تم حذف المستند',
+    deleteError: 'فشل حذف المستند',
+    cancelSuccess: 'تم إلغاء المعالجة',
+    cancelError: 'فشل إلغاء المعالجة',
+
+    // Confirmations
+    confirmDeleteTitle: 'حذف المستند؟',
+    confirmDeleteDesc: 'هل أنت متأكد أنك تريد حذف هذا المستند؟ لا يمكن التراجع عن هذا الإجراء.',
+    confirmCancelTitle: 'إلغاء المعالجة؟',
+    confirmCancelDesc: 'هل أنت متأكد أنك تريد إلغاء معالجة هذا المستند؟',
 
     // Document Preview
     sourceDocument: 'المستند المصدر',
@@ -1154,6 +1194,16 @@ export const translations: Record<Language, Partial<TranslationKeys>> = {
     downloaded: 'تم التحمیل',
     tryAgain: 'تلاش مجدد',
     maxRetriesReached: 'حداکثر تلاش‌ها انجام شد',
+    deleteSuccess: 'سند حذف شد',
+    deleteError: 'حذف سند انجام نشد',
+    cancelSuccess: 'پردازش لغو شد',
+    cancelError: 'لغو پردازش انجام نشد',
+
+    // Confirmations
+    confirmDeleteTitle: 'حذف سند؟',
+    confirmDeleteDesc: 'آیا مطمئن هستید که می‌خواهید این سند را حذف کنید؟ این عمل برگشت‌پذیر نیست.',
+    confirmCancelTitle: 'لغو پردازش؟',
+    confirmCancelDesc: 'آیا مطمئن هستید که می‌خواهید پردازش این سند را لغو کنید؟',
 
     // Document Preview
     sourceDocument: 'سند منبع',


### PR DESCRIPTION
## Summary
- show toast messages when document delete or cancel actions succeed or fail
- ensure cancel actions from the upload queue require confirmation, preventing accidental cancellations

## Testing
- ✅ `npm run lint`
- ⚠️ `npm test` (Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68af2e13ed68832a8a758c7dba84556e