### PR TITLE
Use atob for base64 decoding in edge-safe modules

### DIFF
--- a/lib/ocr/providers/mistral.ts
+++ b/lib/ocr/providers/mistral.ts
@@ -346,7 +346,7 @@ export class MistralOCRProvider implements OCRProvider {
     console.log(`[Mistral] Uploading PDF to Mistral's file API`);
 
     // Convert base64 to binary data
-    const binaryData = Buffer.from(pdfBase64, 'base64');
+    const binaryData = Uint8Array.from(atob(pdfBase64), c => c.charCodeAt(0));
 
     // Create a Blob from the binary data
     const blob = new Blob([binaryData], { type: 'application/pdf' });

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -90,7 +90,9 @@ export async function updateSession(request: NextRequest) {
         let tokenString = authCookie
         if (tokenString.startsWith('base64-')) {
           const base64 = tokenString.slice('base64-'.length)
-          tokenString = Buffer.from(base64, 'base64').toString('utf-8')
+          tokenString = new TextDecoder().decode(
+            Uint8Array.from(atob(base64), c => c.charCodeAt(0))
+          )
         }
         const tokenData = JSON.parse(tokenString)
         const expiresAt = tokenData.expires_at


### PR DESCRIPTION
## Summary
- decode base64 auth cookies with Web API instead of Node Buffer
- remove Buffer usage when uploading PDFs to Mistral API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, missing dependency warnings)*
- `npm run build` *(fails: Unexpected any lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b15c9dd7c8832aa406b4359cda678f