### PR TITLE
refactor: use Web Crypto for JWT verification

### DIFF
--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,4 +1,3 @@
-import { createHmac } from 'crypto'
 import { prodError } from './log'
 
 export interface TokenClaims {
@@ -16,29 +15,57 @@ interface VerifyOptions {
   issuer?: string
 }
 
-export function verifyAccessToken(token: string | undefined, options: VerifyOptions = {}): TokenClaims | null {
+function base64UrlDecode(str: string): Uint8Array {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function verifyAccessToken(
+  token: string | undefined,
+  options: VerifyOptions = {}
+): Promise<TokenClaims | null> {
   try {
-    if (!token) return null
-    const secret = process.env.SUPABASE_JWT_SECRET
+    if (!token) return null;
+    const secret = process.env.SUPABASE_JWT_SECRET;
     if (!secret) {
-      prodError('[JWT] Missing SUPABASE_JWT_SECRET')
-      return null
+      prodError('[JWT] Missing SUPABASE_JWT_SECRET');
+      return null;
     }
 
-    const parts = token.split('.')
-    if (parts.length !== 3) return null
-    const [headerB64, payloadB64, signatureB64] = parts
-    const data = `${headerB64}.${payloadB64}`
-    const expectedSig = createHmac('sha256', secret).update(data).digest('base64url')
-    if (expectedSig !== signatureB64) return null
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const [headerB64, payloadB64, signatureB64] = parts;
+    const data = `${headerB64}.${payloadB64}`;
 
-    const payloadJson = Buffer.from(payloadB64, 'base64url').toString('utf8')
-    const payload = JSON.parse(payloadJson)
-    const now = Math.floor(Date.now() / 1000)
-    if (payload.exp && now >= payload.exp) return null
-    if (payload.nbf && now < payload.nbf) return null
-    if (options.audience && payload.aud !== options.audience) return null
-    if (options.issuer && payload.iss !== options.issuer) return null
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+    const signature = base64UrlDecode(signatureB64);
+    const valid = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      signature,
+      new TextEncoder().encode(data)
+    );
+    if (!valid) return null;
+
+    const payloadJson = new TextDecoder().decode(base64UrlDecode(payloadB64));
+    const payload = JSON.parse(payloadJson);
+    const now = Math.floor(Date.now() / 1000);
+    if (payload.exp && now >= payload.exp) return null;
+    if (payload.nbf && now < payload.nbf) return null;
+    if (options.audience && payload.aud !== options.audience) return null;
+    if (options.issuer && payload.iss !== options.issuer) return null;
 
     return {
       id: payload.sub,
@@ -48,10 +75,10 @@ export function verifyAccessToken(token: string | undefined, options: VerifyOpti
       iss: payload.iss,
       exp: payload.exp,
       nbf: payload.nbf
-    }
+    };
   } catch (e) {
-    prodError('[JWT] Verification failed', e)
-    return null
+    prodError('[JWT] Verification failed', e);
+    return null;
   }
 }
 

--- a/lib/ocr/providers/mistral.ts
+++ b/lib/ocr/providers/mistral.ts
@@ -346,7 +346,7 @@ export class MistralOCRProvider implements OCRProvider {
     console.log(`[Mistral] Uploading PDF to Mistral's file API`);
 
     // Convert base64 to binary data
-    const binaryData = Buffer.from(pdfBase64, 'base64');
+    const binaryData = Uint8Array.from(atob(pdfBase64), c => c.charCodeAt(0));
 
     // Create a Blob from the binary data
     const blob = new Blob([binaryData], { type: 'application/pdf' });

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -99,7 +99,7 @@ export async function getAuthenticatedUser(
     const tokenCookie = cookies.find(c => c.startsWith('sb-access-token='))
     if (tokenCookie) {
       const token = tokenCookie.split('=')[1]
-      const claims = verifyAccessToken(token)
+      const claims = await verifyAccessToken(token)
       if (claims) {
         middlewareLog('important', '[Server-Auth] User authenticated from JWT', {
           email: claims.email

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -90,7 +90,9 @@ export async function updateSession(request: NextRequest) {
         let tokenString = authCookie
         if (tokenString.startsWith('base64-')) {
           const base64 = tokenString.slice('base64-'.length)
-          tokenString = Buffer.from(base64, 'base64').toString('utf-8')
+          tokenString = new TextDecoder().decode(
+            Uint8Array.from(atob(base64), c => c.charCodeAt(0))
+          )
         }
         const tokenData = JSON.parse(tokenString)
         const expiresAt = tokenData.expires_at

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,7 +34,7 @@ export async function middleware(req: NextRequest) {
       }
     }
 
-    const claims = verifyAccessToken(accessToken)
+    const claims = await verifyAccessToken(accessToken)
     if (claims) {
       user = {
         id: claims.id,


### PR DESCRIPTION
## Summary
- replace Node crypto usage with Web Crypto API for HMAC SHA-256
- decode base64url tokens without Buffer for Edge compatibility
- await JWT verification in middleware and server auth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in lib/polyfills.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b15c9f4100832aa71b3b51e89b920a