### PR TITLE
feat: integrate supabase ssr client

### DIFF
--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -16,7 +16,7 @@ export async function GET(
   try {
     // Get the current user using server-side auth
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, req)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('[SERVER] GET /api/documents/[id] - Unauthorized, no user found')
@@ -83,7 +83,7 @@ export async function PUT(
   try {
     // Get the current user using server-side auth
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, req)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('[SERVER] PUT /api/documents/[id] - Unauthorized, no user found')
@@ -206,7 +206,7 @@ export async function DELETE(
   try {
     // Get the current user using server-side auth
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, req)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('[SERVER] DELETE /api/documents/[id] - Unauthorized, no user found')

--- a/app/api/queue/[id]/cancel/route.ts
+++ b/app/api/queue/[id]/cancel/route.ts
@@ -10,7 +10,7 @@ import { middlewareLog, prodError } from '@/lib/log'
  * Cancel processing for a document
  */
 export async function POST(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
@@ -25,7 +25,7 @@ export async function POST(
 
     // Get the current user securely
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, request)
+    const user = await getAuthenticatedUser(supabase)
     if (!user) {
       prodError('[API] POST /api/queue/[id]/cancel - Unauthorized')
       return NextResponse.json(

--- a/app/api/queue/[id]/delete/route.ts
+++ b/app/api/queue/[id]/delete/route.ts
@@ -9,7 +9,7 @@ import { middlewareLog, prodError } from '@/lib/log'
  * Delete a document from the queue
  */
 export async function DELETE(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
@@ -24,7 +24,7 @@ export async function DELETE(
 
     // Create Supabase client and get current user
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, request)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('[API] DELETE /api/queue/[id]/delete - Unauthorized')

--- a/app/api/settings/user/route.ts
+++ b/app/api/settings/user/route.ts
@@ -7,11 +7,11 @@ import { middlewareLog, prodError } from '@/lib/log'
  * GET /api/settings/user
  * Retrieves the user-specific settings
  */
-export async function GET(request: Request) {
+export async function GET() {
   try {
     // Get the current user using server-side auth
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, request)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('GET /api/settings/user - Auth session missing!')
@@ -70,7 +70,7 @@ export async function PUT(request: Request) {
   try {
     // Get the current user using server-side auth
     const supabase = await createServerSupabaseClient()
-    const user = await getAuthenticatedUser(supabase, request)
+    const user = await getAuthenticatedUser(supabase)
 
     if (!user) {
       prodError('[API] PUT /api/settings/user - Unauthorized, no user found')

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.1.7",
-        "@supabase/ssr": "^0.6.1",
+        "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.49.4",
         "buffer": "^6.0.3",
         "class-variance-authority": "^0.7.1",
@@ -1766,12 +1766,12 @@
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
-      "integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.7.0.tgz",
+      "integrity": "sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1"
+        "cookie": "^1.0.2"
       },
       "peerDependencies": {
         "@supabase/supabase-js": "^2.43.4"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.1.7",
-    "@supabase/ssr": "^0.6.1",
+    "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.49.4",
     "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- replace manual cookie parsing in middleware with Supabase SSR client
- streamline server-side auth helpers to use `createServerClient` and `auth.getUser`
- upgrade to `@supabase/ssr@0.7.0` and update API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a5d5b998832a921fe1b32b7e6c7b